### PR TITLE
Update instructions to run on Linux

### DIFF
--- a/doc/authors.rst
+++ b/doc/authors.rst
@@ -29,4 +29,5 @@ Weitere Mitwirkende, in alphabetischer Reihenfolge:
 
 * Friedolin Gröger <friedolin.groeger@student.kit.edu>
 * Lennart Nachtigall <lennart.nachtigall@student.kit.edu>
+* Leptopoda <ufile@student.kit.edu>
 * Felix Rehm <uhezk@student.kit.edu>

--- a/doc/preparation.rst
+++ b/doc/preparation.rst
@@ -174,9 +174,12 @@ Linux
 
 Der Download ist ein AppImage. Die meisten modernen Distributionen können die Datei direkt ausführen.
 Aktivieren Sie dafür das Dateiattribut für "ausführbar" und starten Sie die Datei.
+Einige Distributionen verlangen, dass LenLab als Administrator (Super User) ausgeführt wird.
+Dies zeigt sich durch die Fehlermeldung "Access denied (insufficient permissions)" im Nachrichtenfenster.
 
 Im Terminal:
 
 - Wechseln Sie in das Verzeichnis, in dem das AppImage liegt: `cd [Verzeichnisname]`
 - Aktivieren Sie das Dateiattribut "ausführbar": `chmod +x Lenlab*`
 - Führen Sie die Datei aus: `./Lenlab*`
+- Ausführen als Administrator: `sudo ./Lenlab*`


### PR DESCRIPTION
Some distros require LenLab to be run as superuser.
Just added these instructions to the documentation as it took me a few minutes to realize it :)