### PR TITLE
Set default filetype 'csv' on save dialogue

### DIFF
--- a/doc/authors.rst
+++ b/doc/authors.rst
@@ -27,7 +27,7 @@ Lenlab red (Version 7) wurde geschrieben und wird betreut von:
 
 Weitere Mitwirkende, in alphabetischer Reihenfolge:
 
+* Felix Rehm <uhezk@student.kit.edu>
 * Friedolin Gröger <friedolin.groeger@student.kit.edu>
 * Lennart Nachtigall <lennart.nachtigall@student.kit.edu>
 * Leptopoda <ufile@student.kit.edu>
-* Felix Rehm <uhezk@student.kit.edu>

--- a/lenlab/gui/frequencyform.cpp
+++ b/lenlab/gui/frequencyform.cpp
@@ -170,7 +170,7 @@ void FrequencyForm::activeChanged(bool)
 void
 FrequencyForm::save()
 {
-    QString fileName = QFileDialog::getSaveFileName(this, "Speichern");
+    QString fileName = QFileDialog::getSaveFileName(this, "Speichern", "bode.csv", tr("CSV (*.csv)"));
     try {
         m_frequencysweep->save(fileName);
     }

--- a/lenlab/gui/loggerform.cpp
+++ b/lenlab/gui/loggerform.cpp
@@ -198,7 +198,7 @@ LoggerForm::on_saveButton_clicked()
 void
 LoggerForm::save()
 {
-    QString fileName = QFileDialog::getSaveFileName(this, "Speichern");
+    QString fileName = QFileDialog::getSaveFileName(this, "Speichern", "logger.csv", tr("CSV (*.csv)"));
     try {
         m_voltmeter->save(fileName);
     }

--- a/lenlab/gui/mainwindow.cpp
+++ b/lenlab/gui/mainwindow.cpp
@@ -135,27 +135,33 @@ MainWindow::on_logMessage(QString const & msg)
 void
 MainWindow::on_actionSaveImage_triggered()
 {
-    int index = ui->tabWidget->currentIndex();
-
-    if (index == 0)
-        ui->loggerTab->saveImage();
-    else if (index == 1)
-        ui->oscilloscopeTab->saveImage();
-    else if (index == 2)
-        ui->FrequencyTab->saveImage();
+    switch (ui->tabWidget->currentIndex()){
+        case 0:
+            ui->loggerTab->saveImage();
+            break;
+        case 1:
+            ui->oscilloscopeTab->saveImage();
+            break;
+        case 2:
+            ui->FrequencyTab->saveImage();
+            break;
+    }
 }
 
 void
 MainWindow::on_actionSaveData_triggered()
 {
-    int index = ui->tabWidget->currentIndex();
-
-    if (index == 0)
-        ui->loggerTab->save();
-    else if (index == 1)
-        ui->oscilloscopeTab->save();
-    else if (index == 2)
-        ui->FrequencyTab->save();
+    switch (ui->tabWidget->currentIndex()){
+        case 0:
+            ui->loggerTab->save();
+            break;
+        case 1:
+            ui->oscilloscopeTab->save();
+            break;
+        case 2:
+            ui->FrequencyTab->save();
+            break;
+    }
 }
 
 

--- a/lenlab/gui/oscilloscopeform.cpp
+++ b/lenlab/gui/oscilloscopeform.cpp
@@ -178,7 +178,7 @@ OscilloscopeForm::on_saveButton_clicked()
 void
 OscilloscopeForm::save()
 {
-    QString fileName = QFileDialog::getSaveFileName(this, "Speichern");
+    QString fileName = QFileDialog::getSaveFileName(this, "Speichern", "oszilloskop.csv", tr("CSV (*.csv)"));
     try {
         m_oscilloscope->save(fileName);
     }


### PR DESCRIPTION
- Set default filetype 'csv' on save dialogue
- fix alphabetic ordering of the authors in the documentation

Tested on Archlinux with:
- qmake 3.1
- make 4.3
- gcc 10.2.0
- Qt 5.15.2
- KDE Plasma 5.20.4